### PR TITLE
Change QT console command and add clearer error handling

### DIFF
--- a/GhidraJupyterKotlin/src/main/java/GhidraJupyterKotlin/JupyterKotlinPlugin.java
+++ b/GhidraJupyterKotlin/src/main/java/GhidraJupyterKotlin/JupyterKotlinPlugin.java
@@ -102,11 +102,18 @@ public class JupyterKotlinPlugin extends ProgramPlugin {
 	}
 
 	private void launchQtConsole() {
-		String[] command = {"jupyter", "qtconsole", "--existing", connectionFile.toString()};
+		String[] command = {"jupyter-qtconsole", "--existing", connectionFile.toString()};
 		try {
 			Runtime.getRuntime().exec(command);
 		} catch (IOException e) {
-			e.printStackTrace();
+			Msg.showError(this, null, "QT Console process failed",
+					"The QT Console failed to start because of an IOException.\n" +
+							"Most likely jupyter-qtconsole is not available in your PATH because it wasn't installed\n" +
+							"You can manually run the following command to debug this: \n" +
+							String.join(" ", command) +
+							"\nThe kernel*.json path is optional. Leaving it out will reconnect to your most recent running kernel, which is most likely the correct one.\n" +
+							"You can also run 'jupyter-console --existing' for a terminal based console which is typically already included with a Jupyter install",
+					e);
 		}
 	}
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ to open an already running `juptyter-notebook` server or to start a new one.
 
 ### Kotlin QtConsole
 
+This feature requires the Jupyter QT Console to be installed and `jupyter-qtconsole` to be available in your `PATH`. This is a separate package on PyPI and in most distros, so you typically need to explicitly install it.
+
 Click the ![QtConsole] button to open a QtConsole.
 
 Once you click, a Jupyter Kernel will be initialized in the current Ghidra program


### PR DESCRIPTION
Calling `jupyter-qtconsole` instead of `jupyter qtconsole` makes the issue that the QT console isn't installed more obvious because `.exec` throws an IOError, instead of the `jupyter` command executing and then exiting immediately after. This IOError can then be displayed in the GUI instead of nothing happening.

@tmr232 is there any downside I am missing to calling `jupyter-qtconsole` instead of `jupyter qtconsole`? I would expect this mostly to be an issue with virtual envs, where jupyter is installed in a currently active virtualenv, but jupyter-qtconsole isn't installed in the virtualenv and the global install is used, but this shouldn't be a concern in our use case, since no virtualenvs are involved. 