### PR TITLE
Really bump to 10.0.2 now

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,10 +18,9 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.11
-      - uses: fmagin/setup-ghidra@directLink
+      - uses: er28-0652/setup-ghidra@master
         with:
                 version: "10.0.2"
-                directLink: https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_10.0.1_build/ghidra_10.0.1_PUBLIC_20210708.zip
 
       - name: Build Extension
         working-directory: ./GhidraJupyterKotlin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,9 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.11
-      - uses: fmagin/setup-ghidra@directLink
+      - uses: er28-0652/setup-ghidra@master
         with:
           version: "10.0.2"
-          directLink: https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_10.0.1_build/ghidra_10.0.1_PUBLIC_20210708.zip
 
       - name: Build with Gradle
         working-directory: ./GhidraJupyterKotlin


### PR DESCRIPTION
turns out that I messed up last time and only changed the `version` string not the direct link to the zip which was the actually important part. Now the CI just uses the setup-ghidra action with just the version number again which has been fixed and works with the github releases by default now.