### PR TITLE
Bunch of version bumps

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,7 +20,7 @@ jobs:
           java-version: 1.11
       - uses: er28-0652/setup-ghidra@master
         with:
-                version: "10.0.2"
+                version: "10.1-BETA"
 
       - name: Build Extension
         working-directory: ./GhidraJupyterKotlin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           java-version: 1.11
       - uses: er28-0652/setup-ghidra@master
         with:
-          version: "10.0.2"
+          version: "10.1-BETA"
 
       - name: Build with Gradle
         working-directory: ./GhidraJupyterKotlin

--- a/GhidraJupyterKotlin/build.gradle
+++ b/GhidraJupyterKotlin/build.gradle
@@ -19,6 +19,10 @@ plugins {
 	id 'idea'
 }
 
+
+compileKotlin {
+	kotlinOptions.jvmTarget = "11"
+}
 configurations {
     requiredLibs //.extendsFrom implementation
 }
@@ -51,16 +55,11 @@ else {
 //----------------------END "DO NOT MODIFY" SECTION-------------------------------
 
 dependencies {
-	requiredLibs('org.jetbrains.kotlinx:kotlin-jupyter-kernel:0.9.1-8-1'){ exclude group: "org.slf4j", module: "slf4j-api" }
+	api('org.jetbrains.kotlinx:kotlin-jupyter-kernel:0.10.3-35-1'){ exclude group: "org.slf4j", module: "slf4j-api" }
 	// Needed for compiling
 	// after building they are already included as part of the recursive dependencies of kotlin-jupyter-kernel
 	api group: 'org.jetbrains.kotlin', name: 'kotlin-compiler-embeddable', version: "$kotlinVersion"
-	compile group: 'org.json', name: 'json', version: '20210307'
+	api group: 'org.json', name: 'json', version: '20210307'
 	api group: 'org.zeromq', name: 'jeromq', version: '0.5.2'
-}
-
-task copyDependencies(type: Copy) {
-    from configurations.requiredLibs
-    into 'lib'
 }
 buildExtension.dependsOn(copyDependencies)

--- a/GhidraJupyterKotlin/gradle.properties
+++ b/GhidraJupyterKotlin/gradle.properties
@@ -1,1 +1,1 @@
-kotlinVersion=1.4.32
+kotlinVersion=1.6.0


### PR DESCRIPTION
* Bump kotlin kernel to version 0.10.3-35-1 ("special" release that
only requires Kotlin libraries available on maven, see
https://github.com/Kotlin/kotlin-jupyter/issues/344)

* Bump Kotlin to 1.6.0 (same as the kernel now uses)

* Correctly target Java 11 JVM Bytecode for Kotlin

* Bump to Ghidra 10.1-BETA (and remove copyDependency task, because this
  is now provided)