### PR TITLE
Support Library Descriptor Feature for Easy Access to Extensions/Imports

### DIFF
--- a/GhidraJupyterKotlin/build.gradle
+++ b/GhidraJupyterKotlin/build.gradle
@@ -55,7 +55,7 @@ else {
 //----------------------END "DO NOT MODIFY" SECTION-------------------------------
 
 dependencies {
-	api('org.jetbrains.kotlinx:kotlin-jupyter-kernel:0.10.3-35-1'){ exclude group: "org.slf4j", module: "slf4j-api" }
+	api('org.jetbrains.kotlinx:kotlin-jupyter-kernel:0.11.0-89-1'){ exclude group: "org.slf4j", module: "slf4j-api" }
 	// Needed for compiling
 	// after building they are already included as part of the recursive dependencies of kotlin-jupyter-kernel
 	api group: 'org.jetbrains.kotlin', name: 'kotlin-compiler-embeddable', version: "$kotlinVersion"

--- a/GhidraJupyterKotlin/src/main/java/GhidraJupyterKotlin/InterruptKernelAction.kt
+++ b/GhidraJupyterKotlin/src/main/java/GhidraJupyterKotlin/InterruptKernelAction.kt
@@ -3,6 +3,7 @@ package GhidraJupyterKotlin
 import docking.ActionContext
 import docking.action.DockingAction
 import org.jetbrains.kotlinx.jupyter.*
+import org.jetbrains.kotlinx.jupyter.messaging.*
 import org.jetbrains.kotlinx.jupyter.KernelJupyterParams.Companion.fromFile
 import org.zeromq.ZMQ
 import java.util.*
@@ -15,15 +16,10 @@ class InterruptKernelAction(var parentPlugin: JupyterKotlinPlugin): DockingActio
         // "Cannot interrupt a kernel I did not start"
         // when using the "Interrupt Kernel" menu entry
 
-        // This creates a ZMQ socket, to send an interrupt request to the running kernel
-        // This is needed because Jupyter QT Console doesn't seem to provide this feature and just prints
-        // "Cannot interrupt a kernel I did not start"
-        // when using the "Interrupt Kernel" menu entry
-
         val config: KernelJupyterParams = fromFile(parentPlugin.connectionFile)
 
-        val context = ZMQ.context(1)
-        val control = context.socket(JupyterSockets.CONTROL.zmqClientType)
+        val ctx = ZMQ.context(1)
+        val control = ctx.socket(JupyterSockets.CONTROL.zmqClientType)
         control.connect("${config.transport}://*:${config.ports[JupyterSockets.CONTROL.ordinal]}")
         if (config.sigScheme == "hmac-sha256"){
             val hmac = HMAC("HmacSHA256", config.key!!)

--- a/GhidraJupyterKotlin/src/main/java/GhidraJupyterKotlin/JupyterKotlinPlugin.java
+++ b/GhidraJupyterKotlin/src/main/java/GhidraJupyterKotlin/JupyterKotlinPlugin.java
@@ -74,6 +74,11 @@ public class JupyterKotlinPlugin extends ProgramPlugin {
 		registerActions();
 	}
 
+	public void clearKernel() {
+		currentKernel = null;
+	}
+
+
 	private void registerActions(){
 		DockingAction action = new DockingAction("Kotlin QtConsole", getName()) {
 			@Override
@@ -139,14 +144,7 @@ public class JupyterKotlinPlugin extends ProgramPlugin {
 		interruptAction.setDescription("Interrupts the currently running kernel if it is executing something");
 		tool.addAction(interruptAction);
 
-
-		DockingAction shutdownAction = new DockingAction("Jupyter Server", getName()) {
-			@Override
-			public void actionPerformed(ActionContext context) {
-				runManager.cancelAllRunnables();
-				currentKernel = null;
-			}
-		};
+		DockingAction shutdownAction = new ShutDownKernelAction(this);
 		shutdownAction.setMenuBarData(
 				new MenuData(new String[] { "Jupyter", "Shutdown Kernel" }, null, null));
 		shutdownAction.setDescription("Terminates the currently running kernel if it isn't busy");

--- a/GhidraJupyterKotlin/src/main/java/GhidraJupyterKotlin/KotlinQtConsoleThread.java
+++ b/GhidraJupyterKotlin/src/main/java/GhidraJupyterKotlin/KotlinQtConsoleThread.java
@@ -5,6 +5,7 @@ import ghidra.util.task.MonitoredRunnable;
 import ghidra.util.task.TaskMonitor;
 import org.jetbrains.kotlinx.jupyter.IkotlinKt;
 import org.jetbrains.kotlinx.jupyter.libraries.EmptyResolutionInfoProvider;
+import org.zeromq.ZMQException;
 
 import java.io.*;
 import java.util.*;
@@ -22,10 +23,14 @@ public class KotlinQtConsoleThread implements KernelThread {
     @Override
     public void monitoredRun(TaskMonitor monitor) {
         Msg.info(this, connectionFile.toString());
-        IkotlinKt.embedKernel(
-                connectionFile,
-                EmptyResolutionInfoProvider.INSTANCE,
-                Collections.singletonList(context));
+        try {
+            IkotlinKt.embedKernel(
+                    connectionFile,
+                    EmptyResolutionInfoProvider.INSTANCE,
+                    Collections.singletonList(context));
+        } catch( ZMQException e){
+           Msg.warn(this,"Kernel terminated, probably because of shutdown request?", e);
+        }
     }
 
     @Override

--- a/GhidraJupyterKotlin/src/main/java/GhidraJupyterKotlin/ShutDownKernelAction.kt
+++ b/GhidraJupyterKotlin/src/main/java/GhidraJupyterKotlin/ShutDownKernelAction.kt
@@ -1,0 +1,36 @@
+package GhidraJupyterKotlin
+
+import docking.ActionContext
+import docking.action.DockingAction
+import org.jetbrains.kotlinx.jupyter.*
+import org.jetbrains.kotlinx.jupyter.messaging.*
+import org.jetbrains.kotlinx.jupyter.KernelJupyterParams.Companion.fromFile
+import org.zeromq.ZMQ
+import java.util.*
+
+
+class ShutDownKernelAction(var parentPlugin: JupyterKotlinPlugin): DockingAction("Interrupt Kernel", parentPlugin.name) {
+    override fun actionPerformed(context: ActionContext?) {
+        // This creates a ZMQ socket, to send a shutdown request to the running kernel
+        // This is basically a duplicate of InterruptKernelAction and could be merged in the future
+        val config: KernelJupyterParams = fromFile(parentPlugin.connectionFile)
+
+        val ctx = ZMQ.context(1)
+        val control = ctx.socket(JupyterSockets.CONTROL.zmqClientType)
+        control.connect("${config.transport}://*:${config.ports[JupyterSockets.CONTROL.ordinal]}")
+        if (config.sigScheme == "hmac-sha256"){
+            val hmac = HMAC("HmacSHA256", config.key!!)
+            control.sendMessage(
+                Message(id = listOf(byteArrayOf(1)),
+                    MessageData(
+                        header = makeHeader(
+                            MessageType.SHUTDOWN_REQUEST,
+                            sessionId = UUID.randomUUID().toString()),
+                        content = ShutdownRequest(false))),
+                hmac)
+            parentPlugin.clearKernel()
+        }
+
+
+    }
+}


### PR DESCRIPTION
This allows adding a file like
```json
{
  "link": "https://github.com/GhidraJupyter/ghidra-jupyter-kotlin",
  "description": "Shortcut to load features in Kotlin Kernel",
  "imports": [
    "GhidraJupyterKotlin.extensions.address.*",
    "GhidraJupyterKotlin.extensions.data.*",
    "GhidraJupyterKotlin.extensions.misc.*"

  ]
}
```
to `$HOME/.jupyter_kotlin/libraries/`, e.g. with the name `ghidraJupyter.json` 
and then run `%use ghidraJupyter` in the kernel to automatically import those packages (and thus register the extension functions). This also supports various other features like registering renderers for specific types, running certain code on initial import and more. See https://github.com/Kotlin/kotlin-jupyter/blob/stable-kotlin-2/docs/libraries.md

I still want to test this for a bit before merging, and maybe the hack with the invalid homedir can be removed by then anyway, then this would just require bumping to a new stable release of the kernel.