### PR TITLE
Make sure jupyter runtime dir actually exists before trying to write connection file

### DIFF
--- a/GhidraJupyterKotlin/src/main/java/GhidraJupyterKotlin/ConnectionFile.java
+++ b/GhidraJupyterKotlin/src/main/java/GhidraJupyterKotlin/ConnectionFile.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -87,6 +88,16 @@ public class ConnectionFile {
         }
         String runtimeDir = getJupyterRuntime();
         File kernelFile = new File(runtimeDir, String.format("kernel-%s.json", key));
+        // Make sure that the directory actually exists
+        // this is not guaranteed by only invoking `jupyter --runtime-dir`
+        // on new machines that never did anything with jupyter the directory won't exist
+        // and writing the file will fail
+        try {
+            Files.createDirectories(kernelFile.getParentFile().toPath());
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
 
         String connectionFile = formatConnectionFile(key, ports);
 


### PR DESCRIPTION
I don't know if there is a more elegant way to solve this, nor do I know when the IOException in `createDirectories` will actually be thrown, but this at least means that you can start a kernel and console on a freshly installed system that has never used Jupyter before.
The only user facing error before was a exception that the connection file was  null, which and the issue that the connection file failed to _write_ was only visible on the console.