### PR TITLE
Add parsed length check to version extraction logic.

### DIFF
--- a/ghidra_jupyter/src/ghidra_jupyter/installer.py
+++ b/ghidra_jupyter/src/ghidra_jupyter/installer.py
@@ -53,7 +53,10 @@ def _get_ghidra_version(ghidra_install_dir: Optional[str]) -> version.Version:
     app_properties = os.path.join(ghidra_install_dir, "Ghidra", "application.properties")
     with open(app_properties, "r") as f:
         for line in f.readlines():
-            key, value = line.split("=")
+            prop_split = line.split("=")
+            if len(prop_split) != 2:
+                continue
+            key, value = prop_split
             if key == "application.version":
                 return version.parse(value)
 


### PR DESCRIPTION
Some Ghidra application property keys do not have a value by default.

An example:
```
#Tue Jul 09 11:57:19 EDT 2024
application.build.date=2024-Jul-09 1157 EDT
application.gradle.min=7.3
application.java.max=
application.version=11.1.2
application.build.date.short=20240709
application.revision.ghidra.bin=c60802a1f850eda32f60cabc62f5450ad0a06099
application.release.marking=
application.java.compiler=17
application.gradle.max=
application.revision.ghidra=68cad06ddfae2b92c03054357c67c32f2d0553a8
application.java.min=17
application.revision.ghidra.ext-u=3b90a9066ba09c26bb9595098fa4a625f72c2699
application.layout.version=2
application.release.name=PUBLIC
application.name=Ghidra
```

Under this condition, running `ghidra-jupyter install-extension`, will attempt to unpack an array with less than two values inside `_get_ghidra_version`. 

This results in the following `ValueError`:
```
Traceback (most recent call last):
  File "/Users/and/ghidra_jupyter/venv/bin/ghidra-jupyter", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/and/ghidra_jupyter/venv/lib/python3.12/site-packages/ghidra_jupyter/installer.py", line 172, in main
    install_extension(args.ghidra, args.extension_path, args.extension_url)
  File "/Users/and/ghidra_jupyter/venv/lib/python3.12/site-packages/ghidra_jupyter/installer.py", line 78, in install_extension
    ghidra_version = _get_ghidra_version(ghidra_install_dir)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/and/ghidra_jupyter/venv/lib/python3.12/site-packages/ghidra_jupyter/installer.py", line 56, in _get_ghidra_version
    key, value = line.split("=")
    ^^^^^^^^^^
```